### PR TITLE
Increased darkening of button background-color on active

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -523,10 +523,10 @@
     *background-color: darken(@endColor, 5%);
   }
 
-  // IE 7 + 8 can't handle box-shadow to show active, so we darken a bit ourselves
+  // Darken ourselves a bit more
   &:active,
   &.active {
-    background-color: darken(@endColor, 10%) e("\9");
+    background-color: darken(@endColor, 10%);
   }
 }
 


### PR DESCRIPTION
Increases the contrast between active and inactive buttons from this
![image](https://f.cloud.github.com/assets/1646006/788355/e55cb86e-eaf9-11e2-99af-ce2ccafa29c3.png)

to this
![image](https://f.cloud.github.com/assets/1646006/788350/b6641e76-eaf9-11e2-8a14-50d3fbd0f92c.png)

This is the same as used in ie7 and 8 (where box-shadows aren't available).
It's also used in guthub

![image](https://f.cloud.github.com/assets/1646006/788354/d5687510-eaf9-11e2-89c2-1c835792baec.png)
