### PR TITLE
fix tool tip error on IE9

### DIFF
--- a/js/bootstrap-tooltip.js
+++ b/js/bootstrap-tooltip.js
@@ -289,15 +289,12 @@
       return this.getTitle()
     }
 
-    /* 
-    a common issue on IE9 and older versions 
-    that .offset() does fail against disconnected DOM
-    a suggested fix is to hide the error    
-    https://github.com/jquery/jquery/commit/cf672a2e7a886cac5ae62f6772c6b4b43b19a2fc
-    */
   , getPosition: function() {
       var el = this.$element[0]
       var pos;
+
+      // .getBoundingClientRect() fails for disconnected DOM elements, apply same fix as jquery
+      // https://github.com/jquery/jquery/commit/cf672a2e7a886cac5ae62f6772c6b4b43b19a2fc
       try {
         if ( ( typeof el.getBoundingClientRect == 'function' ) ) {
           pos = el.getBoundingClientRect()


### PR DESCRIPTION
a common issue on IE9 and older versions that .offset() does fail against disconnected DOM a suggested fix is to hide the [error](https://github.com/jquery/jquery/commit/cf672a2e7a886cac5ae62f6772c6b4b43b19a2fc)
