### PR TITLE
Setting alert text colours back to grey

### DIFF
--- a/less/alerts.less
+++ b/less/alerts.less
@@ -17,7 +17,7 @@
 .alert,
 .alert h4 {
   // Specified for the h4 to prevent conflicts of changing @headingsColor
-  color: @warningText;
+  color: #555;
 }
 .alert h4 {
   margin: 0;
@@ -38,28 +38,28 @@
 .alert-success {
   background-color: @successBackground;
   border-color: @successBorder;
-  color: @successText;
+  color: #555;
 }
 .alert-success h4 {
-  color: @successText;
+  color: #555;
 }
 .alert-danger,
 .alert-error {
   background-color: @errorBackground;
   border-color: @errorBorder;
-  color: @errorText;
+  color: #555;
 }
 .alert-danger h4,
 .alert-error h4 {
-  color: @errorText;
+  color: #555;
 }
 .alert-info {
   background-color: @infoBackground;
   border-color: @infoBorder;
-  color: @infoText;
+  color: #555;
 }
 .alert-info h4 {
-  color: @infoText;
+  color: #555;
 }
 
 


### PR DESCRIPTION
Porting changes to `alerts.less` from JLR commits [008a0d1](https://github.com/configit/jlr/commit/008a0d1007f2c77e5616f53a2b4ac84f1f7dc943) and [abd8670](https://github.com/configit/jlr/commit/abd86706e7306acccc816a1170d45e63bef1b807).